### PR TITLE
patch ImagePickerIOS to return video width and height

### DIFF
--- a/Libraries/CameraRoll/RCTImagePickerManager.m
+++ b/Libraries/CameraRoll/RCTImagePickerManager.m
@@ -17,6 +17,8 @@
 #import <React/RCTRootView.h>
 #import <React/RCTUtils.h>
 
+@import Photos;
+
 @interface RCTImagePickerController : UIImagePickerController
 
 @property (nonatomic, assign) BOOL unmirrorFrontFacingCamera;
@@ -146,6 +148,16 @@ didFinishPickingMediaWithInfo:(NSDictionary<NSString *, id> *)info
     height = @(image.size.height);
     width = @(image.size.width);
   }
+  
+  if (isMovie) {
+    PHFetchResult<PHAsset *> *assets = [PHAsset fetchAssetsWithALAssetURLs:@[[info valueForKey:UIImagePickerControllerReferenceURL]] options:nil];
+    if (assets.count > 0) {
+      PHAsset *videoAsset = assets.firstObject;
+      width = @(videoAsset.pixelWidth);
+      height = @(videoAsset.pixelHeight);
+    }
+  }
+  
   if (imageURL) {
     [self _dismissPicker:picker args:@[imageURL.absoluteString, RCTNullIfNil(height), RCTNullIfNil(width)]];
     return;

--- a/Libraries/CameraRoll/RCTImagePickerManager.m
+++ b/Libraries/CameraRoll/RCTImagePickerManager.m
@@ -147,14 +147,12 @@ didFinishPickingMediaWithInfo:(NSDictionary<NSString *, id> *)info
   if (image) {
     height = @(image.size.height);
     width = @(image.size.width);
-  }
-  
-  if (isMovie) {
+  } else if (isMovie) {
     PHFetchResult<PHAsset *> *assets = [PHAsset fetchAssetsWithALAssetURLs:@[[info valueForKey:UIImagePickerControllerReferenceURL]] options:nil];
     if (assets.count > 0) {
       PHAsset *videoAsset = assets.firstObject;
-      width = @(videoAsset.pixelWidth);
       height = @(videoAsset.pixelHeight);
+      width = @(videoAsset.pixelWidth);
     }
   }
   


### PR DESCRIPTION
Currently `ImagePickerIOS` does not return a width or height for videos selected in the Photo Library. This change patches our RN repo to grab the width and height data from the PHAsset and return it to JS through ImagePickerIOS. 

This code was shamelessly stolen from Expo, who already handles this case:
https://github.com/expo/expo/blob/master/packages/expo-image-picker/ios/EXImagePicker/EXImagePicker.m#L297