### PR TITLE
placeholder image patch

### DIFF
--- a/Libraries/Text/Text/RCTTextShadowView.m
+++ b/Libraries/Text/Text/RCTTextShadowView.m
@@ -168,6 +168,19 @@
                          range:NSMakeRange(0, attributedText.length)];
 }
 
+// iOS 13 attributed string attachments have placeholder images
+// https://github.com/facebook/react-native/pull/26653/files
+static UIImage *emptyImg = NULL;
+- (UIImage*)getEmptyImg
+{
+  if (emptyImg == NULL) {
+    UIGraphicsBeginImageContextWithOptions(CGSizeMake(1, 1), NO, 0);
+    emptyImg = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+  }
+  return emptyImg;
+}
+
 - (NSAttributedString *)attributedTextWithMeasuredAttachmentsThatFitSize:(CGSize)size
 {
   NSMutableAttributedString *attributedText =
@@ -188,6 +201,7 @@
                                                    maximumSize:size];
       NSTextAttachment *attachment = [NSTextAttachment new];
       attachment.bounds = (CGRect){CGPointZero, fittingSize};
+      [attachment setImage:[self getEmptyImg]];
       [attributedText addAttribute:NSAttachmentAttributeName value:attachment range:range];
     }
   ];
@@ -297,7 +311,7 @@
         RCTRoundPixelValue(attachmentSize.width),
         RCTRoundPixelValue(attachmentSize.height)
       }};
-      
+
       NSRange truncatedGlyphRange = [layoutManager truncatedGlyphRangeInLineFragmentForGlyphAtIndex:range.location];
       BOOL viewIsTruncated = NSIntersectionRange(range, truncatedGlyphRange).length != 0;
 


### PR DESCRIPTION
iOS13 puts a placeholder behind `Image` components within `Text`

Before:
![Screen Shot 2019-10-10 at 5 24 26 PM](https://user-images.githubusercontent.com/1054402/66615814-1067ec00-eb83-11e9-9173-bdf0fd74192a.png)

After:
![Screen Shot 2019-10-10 at 5 15 10 PM](https://user-images.githubusercontent.com/1054402/66615815-1067ec00-eb83-11e9-8dfc-c4cc1cedada7.png)
