### PR TITLE
iOS13 status bar has now 3 styles (#26294)

### DIFF
--- a/React/Modules/RCTStatusBarManager.m
+++ b/React/Modules/RCTStatusBarManager.m
@@ -144,6 +144,7 @@ RCT_EXPORT_METHOD(setStyle : (UIStatusBarStyle)statusBarStyle animated : (BOOL)a
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [RCTSharedApplication() setStatusBarStyle:statusBarStyle animated:animated];
   }
+#pragma clang diagnostic pop
 }
 
 RCT_EXPORT_METHOD(setHidden : (BOOL)hidden withAnimation : (UIStatusBarAnimation)animation)

--- a/React/Modules/RCTStatusBarManager.m
+++ b/React/Modules/RCTStatusBarManager.m
@@ -14,17 +14,44 @@
 #if !TARGET_OS_TV
 @implementation RCTConvert (UIStatusBar)
 
-RCT_ENUM_CONVERTER(UIStatusBarStyle, (@{
-  @"default": @(UIStatusBarStyleDefault),
-  @"light-content": @(UIStatusBarStyleLightContent),
-  @"dark-content": @(UIStatusBarStyleDefault),
-}), UIStatusBarStyleDefault, integerValue);
++ (UIStatusBarStyle)UIStatusBarStyle:(id)json RCT_DYNAMIC
+{
+  static NSDictionary *mapping;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    if (@available(iOS 13.0, *)) {
+      mapping = @{
+        @"default" : @(UIStatusBarStyleDefault),
+        @"light-content" : @(UIStatusBarStyleLightContent),
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+        @"dark-content" : @(UIStatusBarStyleDarkContent)
+#else
+          @"dark-content": @(UIStatusBarStyleDefault)
+#endif
+      };
 
-RCT_ENUM_CONVERTER(UIStatusBarAnimation, (@{
-  @"none": @(UIStatusBarAnimationNone),
-  @"fade": @(UIStatusBarAnimationFade),
-  @"slide": @(UIStatusBarAnimationSlide),
-}), UIStatusBarAnimationNone, integerValue);
+    } else {
+      mapping = @{
+        @"default" : @(UIStatusBarStyleDefault),
+        @"light-content" : @(UIStatusBarStyleLightContent),
+        @"dark-content" : @(UIStatusBarStyleDefault)
+      };
+    }
+  });
+  return _RCT_CAST(
+      type, [RCTConvertEnumValue("UIStatusBarStyle", mapping, @(UIStatusBarStyleDefault), json) integerValue]);
+}
+
+RCT_ENUM_CONVERTER(
+    UIStatusBarAnimation,
+    (@{
+      @"none" : @(UIStatusBarAnimationNone),
+      @"fade" : @(UIStatusBarAnimationFade),
+      @"slide" : @(UIStatusBarAnimationSlide),
+    }),
+    UIStatusBarAnimationNone,
+    integerValue);
 
 @end
 #endif
@@ -36,8 +63,9 @@ static BOOL RCTViewControllerBasedStatusBarAppearance()
   static BOOL value;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    value = [[[NSBundle mainBundle] objectForInfoDictionaryKey:
-              @"UIViewControllerBasedStatusBarAppearance"] ?: @YES boolValue];
+    value =
+        [[[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIViewControllerBasedStatusBarAppearance"]
+                ?: @YES boolValue];
   });
 
   return value;
@@ -47,8 +75,7 @@ RCT_EXPORT_MODULE()
 
 - (NSArray<NSString *> *)supportedEvents
 {
-  return @[@"statusBarFrameDidChange",
-           @"statusBarFrameWillChange"];
+  return @[ @"statusBarFrameDidChange", @"statusBarFrameWillChange" ];
 }
 
 #if !TARGET_OS_TV
@@ -56,8 +83,14 @@ RCT_EXPORT_MODULE()
 - (void)startObserving
 {
   NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-  [nc addObserver:self selector:@selector(applicationDidChangeStatusBarFrame:) name:UIApplicationDidChangeStatusBarFrameNotification object:nil];
-  [nc addObserver:self selector:@selector(applicationWillChangeStatusBarFrame:) name:UIApplicationWillChangeStatusBarFrameNotification object:nil];
+  [nc addObserver:self
+         selector:@selector(applicationDidChangeStatusBarFrame:)
+             name:UIApplicationDidChangeStatusBarFrameNotification
+           object:nil];
+  [nc addObserver:self
+         selector:@selector(applicationWillChangeStatusBarFrame:)
+             name:UIApplicationWillChangeStatusBarFrameNotification
+           object:nil];
 }
 
 - (void)stopObserving
@@ -74,11 +107,11 @@ RCT_EXPORT_MODULE()
 {
   CGRect frame = [notification.userInfo[UIApplicationStatusBarFrameUserInfoKey] CGRectValue];
   NSDictionary *event = @{
-    @"frame": @{
-      @"x": @(frame.origin.x),
-      @"y": @(frame.origin.y),
-      @"width": @(frame.size.width),
-      @"height": @(frame.size.height),
+    @"frame" : @{
+      @"x" : @(frame.origin.x),
+      @"y" : @(frame.origin.y),
+      @"width" : @(frame.size.width),
+      @"height" : @(frame.size.height),
     },
   };
   [self sendEventWithName:eventName body:event];
@@ -94,42 +127,43 @@ RCT_EXPORT_MODULE()
   [self emitEvent:@"statusBarFrameWillChange" forNotification:notification];
 }
 
-RCT_EXPORT_METHOD(getHeight:(RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(getHeight : (RCTResponseSenderBlock)callback)
 {
-  callback(@[@{
-    @"height": @(RCTSharedApplication().statusBarFrame.size.height),
-  }]);
+  callback(@[ @{
+    @"height" : @(RCTSharedApplication().statusBarFrame.size.height),
+  } ]);
 }
 
-RCT_EXPORT_METHOD(setStyle:(UIStatusBarStyle)statusBarStyle
-                  animated:(BOOL)animated)
-{
-  if (RCTViewControllerBasedStatusBarAppearance()) {
-    RCTLogError(@"RCTStatusBarManager module requires that the \
-                UIViewControllerBasedStatusBarAppearance key in the Info.plist is set to NO");
-  } else {
-    [RCTSharedApplication() setStatusBarStyle:statusBarStyle
-                                     animated:animated];
-  }
-}
-
-RCT_EXPORT_METHOD(setHidden:(BOOL)hidden
-                  withAnimation:(UIStatusBarAnimation)animation)
+RCT_EXPORT_METHOD(setStyle : (UIStatusBarStyle)statusBarStyle animated : (BOOL)animated)
 {
   if (RCTViewControllerBasedStatusBarAppearance()) {
     RCTLogError(@"RCTStatusBarManager module requires that the \
                 UIViewControllerBasedStatusBarAppearance key in the Info.plist is set to NO");
   } else {
-    [RCTSharedApplication() setStatusBarHidden:hidden
-                                 withAnimation:animation];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    [RCTSharedApplication() setStatusBarStyle:statusBarStyle animated:animated];
   }
 }
 
-RCT_EXPORT_METHOD(setNetworkActivityIndicatorVisible:(BOOL)visible)
+RCT_EXPORT_METHOD(setHidden : (BOOL)hidden withAnimation : (UIStatusBarAnimation)animation)
+{
+  if (RCTViewControllerBasedStatusBarAppearance()) {
+    RCTLogError(@"RCTStatusBarManager module requires that the \
+                UIViewControllerBasedStatusBarAppearance key in the Info.plist is set to NO");
+  } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    [RCTSharedApplication() setStatusBarHidden:hidden withAnimation:animation];
+#pragma clang diagnostic pop
+  }
+}
+
+RCT_EXPORT_METHOD(setNetworkActivityIndicatorVisible : (BOOL)visible)
 {
   RCTSharedApplication().networkActivityIndicatorVisible = visible;
 }
 
-#endif //TARGET_OS_TV
+#endif // TARGET_OS_TV
 
 @end


### PR DESCRIPTION
We cherry-pick this commit https://github.com/facebook/react-native/commit/796b3a1f8823c87c9a066ea9c51244710dc0b9b5 to fix dark theme status bar

Summary:
iOS13 status bar has now 3 styles
UIStatusBarStyleDefault, UIStatusBarStyleLightContent, UIStatusBarStyleDarkContent

UIStatusBarStyleDefault now acts as an automatic style which will set it’s value dynamically based on the the userinterfacestyle(One of the traits) of the viewcontroller that controls the status bar appearance.

[iOS] [Fixed] - iOS13 new status bar style UIStatusBarStyleDarkContent
Pull Request resolved: https://github.com/facebook/react-native/pull/26294

Differential Revision: D17314054

Pulled By: cpojer

fbshipit-source-id: ea109e729bb551dff314bc00a056860a8febb0e9

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
